### PR TITLE
Fix default avatar urls trying/failing to use webp; update tree data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,170 @@
+# Created by https://www.toptal.com/developers/gitignore/api/flask
+# Edit at https://www.toptal.com/developers/gitignore?templates=flask
+
+### Flask ###
+instance/*
+!instance/.gitignore
+.webassets-cache
+.env
+
+### Flask.Python Stack ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# End of https://www.toptal.com/developers/gitignore/api/flask

--- a/.glitch-assets
+++ b/.glitch-assets
@@ -14,3 +14,5 @@
 {"name":"site.webmanifest","date":"2024-07-04T00:39:18.471Z","url":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/site.webmanifest","type":"","size":452,"thumbnail":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/thumbnails%2Fsite.webmanifest","thumbnailWidth":210,"thumbnailHeight":210,"uuid":"qXjTIAW3Gcy3wFV1"}
 {"uuid":"qXjTIAW3Gcy3wFV1","deleted":true}
 {"name":"site.webmanifest","date":"2024-07-04T00:44:15.641Z","url":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/site.webmanifest","type":"","size":582,"thumbnail":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/thumbnails%2Fsite.webmanifest","thumbnailWidth":210,"thumbnailHeight":210,"uuid":"oZlk9Z6YmLEcqdB5"}
+{"name":"failed.webp","date":"2024-07-04T20:05:13.054Z","url":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.webp","type":"image/webp","size":1722,"imageWidth":256,"imageHeight":256,"thumbnail":"https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.webp","thumbnailWidth":256,"thumbnailHeight":256,"uuid":"igLPWifLtQMVI3Xh"}
+{"uuid":"4Htz63xQwSjKw3uC","deleted":true}

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ChromaticPixels
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+will make proper once minimum functionality is done -- but i'll at least share the origin
+
+there's a youtuber called MagicGum who had a Minecraft server called Trapped SMP; the Discord community was shockingly enthusiastic pre-launch, and among other things, they made a family tree containing many prominent members
+
+the server is long dead, but the Discord remains, and the family tree is maintained there; i made this with the intent to make that maintenence easier and to also let others make their own Discord family trees
+
+if you find issues, do share :> -- i'll try to use my barely functional skills to fix em

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ app = Quart(__name__)
 Compress(app)
 
 # specifies avatar url for failed users
-default_avatar_url = "https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.png?v=1719901676048"
+default_avatar_url = "https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.webp?size=64"
 
 # home
 @app.route('/')
@@ -96,23 +96,24 @@ async def user_data(server=False, id=None):
             username = f"error [ID: {id}]"
         else:
             success = True
-            # gets avatar url so that the ternary below isn't ugly
-            avatar = user.display_avatar_url
-            # avatar if avatar exists, else default avatar
-            avatar = str(
-                avatar if avatar is not None
-                else user.default_avatar_url
-            )
+            # gets avatar url
+            avatar = str(user.display_avatar_url)
+            # if avatar isn't default
+            if "embed" not in avatar.split("/avatars/")[0]:
+              # convert to webp (default ones don't support a webp request)
+              avatar = avatar.replace(".png", ".webp")
             # other user info
             username = user.username
             # prints username for the sake of logging
             print(user.username)
     # closes connection
     await rest_app.close()
+    print(avatar)
     return {
         str(id): {
             "username": username,
-            "avatar": avatar, # avatar url
+            # sets img size
+            "avatar": avatar.split("?")[0] + "?size=64",
             "success": success
         }
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html>
     <head>
         <title>gumTree</title>
-        <meta charset="utf-8" name="viewport" content="width=device-width">
+        <meta charset="utf-8" name="viewport" content="width=device-width, initial-scale=1">
         <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/apple-touch-icon.png?v=1720053554579">
         <link rel="icon" type="image/png" sizes="32x32" href="https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/favicon-32x32.png?v=1720053555954">
         <link rel="icon" type="image/png" sizes="16x16" href="https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/favicon-16x16.png?v=1720053555772">
@@ -158,7 +158,7 @@
         </div>
         <div id="box"></div>
         <svg id="lines" height="100000px" width="100000px"></svg>
-        <script src="https://unpkg.com/anim-event@1.0.17/anim-event.min.js"></script>
+        <script>/*! AnimEvent v1.0.17 (c) anseki https://github.com/anseki/anim-event */var AnimEvent=function(n){var e={};function t(r){if(e[r])return e[r].exports;var o=e[r]={i:r,l:!1,exports:{}};return n[r].call(o.exports,o,o.exports,t),o.l=!0,o.exports}return t.m=n,t.c=e,t.d=function(n,e,r){t.o(n,e)||Object.defineProperty(n,e,{enumerable:!0,get:r})},t.r=function(n){"undefined"!=typeof Symbol&&Symbol.toStringTag&&Object.defineProperty(n,Symbol.toStringTag,{value:"Module"}),Object.defineProperty(n,"__esModule",{value:!0})},t.t=function(n,e){if(1&e&&(n=t(n)),8&e)return n;if(4&e&&"object"==typeof n&&n&&n.__esModule)return n;var r=Object.create(null);if(t.r(r),Object.defineProperty(r,"default",{enumerable:!0,value:n}),2&e&&"string"!=typeof n)for(var o in n)t.d(r,o,function(e){return n[e]}.bind(null,o));return r},t.n=function(n){var e=n&&n.__esModule?function(){return n.default}:function(){return n};return t.d(e,"a",e),e},t.o=function(n,e){return Object.prototype.hasOwnProperty.call(n,e)},t.p="",t(t.s=0)}([function(n,e,t){"use strict";t.r(e);var r,o=[],i=window.requestAnimationFrame||window.mozRequestAnimationFrame||window.webkitRequestAnimationFrame||window.msRequestAnimationFrame||function(n){return setTimeout(n,1e3/60)},u=window.cancelAnimationFrame||window.mozCancelAnimationFrame||window.webkitCancelAnimationFrame||window.msCancelAnimationFrame||function(n){return clearTimeout(n)},a=Date.now();function l(){var n,e;r&&(u.call(window,r),r=null),o.forEach((function(e){var t;(t=e.event)&&(e.event=null,e.listener(t),n=!0)})),n?(a=Date.now(),e=!0):Date.now()-a<500&&(e=!0),e&&(r=i.call(window,l))}function c(n){var e=-1;return o.some((function(t,r){return t.listener===n&&(e=r,!0)})),e}var f={add:function(n){var e;return-1===c(n)?(o.push(e={listener:n}),function(n){e.event=n,r||l()}):null},remove:function(n){var e;(e=c(n))>-1&&(o.splice(e,1),!o.length&&r&&(u.call(window,r),r=null))}};e.default=f}]).default;</script>
         <script>
             window.selectedUser = undefined;
             window.selectedConnectionType = undefined
@@ -167,7 +167,7 @@
             window.openUserMenus = true;
             window.outlineSelectHTML = '<option value="none">none</option>';
             window.usersForDeletion = [];
-            window.defaultAvatarURL = "https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.png?v=1719901676048"
+            window.defaultAvatarURL = "https://cdn.glitch.global/269cebce-0e77-45c8-8657-9e20c05be5bd/failed.webp?size=64"
             function urlExists(url, callback) {
                 fetch(url, {
                   method: 'get',
@@ -189,7 +189,7 @@
                     .then((userdata) => {func(userdata)})
             }
             function displayUser(id, userdata) {
-                let avatar_url = userdata.avatar.split('?')[0] + "?size=64";
+                let avatar_url = userdata.avatar;
                 urlExists(avatar_url, function(exists) {
                     if (!exists) {
                        avatar_url = window.defaultAvatarURL;
@@ -623,8 +623,8 @@
                 user.style.top = `${Math.random() * (window.screen.height - 256) + 32 + (bound.height / 2)}px`;
             }
             function createUserEl([id, udata]) {
-                let avatar_url = udata.avatar.split('?')[0] + "?size=64";
-                document.querySelector("#box").innerHTML += `<img id="u${id}" data-connectedwith="" class="user" src="${avatar_url}" alt="refresh me" style="outline: 0px solid;"></img>`;}
+                let avatar_url = udata.avatar;
+                document.querySelector("#box").innerHTML += `<img id="u${id}" data-connectedwith="" class="user" src="${avatar_url}" alt="refresh me" style="outline: 0px solid;" width="64px" height="64px"></img>`;}
             function addUsers() {
                 let rawList = prompt("enter a comma-separated (NO SPACES) list of ids: \ninvalid ids will NOT be alerted because i goddamn hate async functions and i don't feel like dealing with looping them\n\nadded users will be randomly dropped in the page's center (hint: use the button)");
                 if (!rawList) {

--- a/trees/t0001.json
+++ b/trees/t0001.json
@@ -54,347 +54,347 @@
     },
     "user_info": {
         "1058531428280840283": {
-            "avatar": "https://cdn.discordapp.com/avatars/1058531428280840283/8b8d0b240fa9d41a93de38c4c6eec0f3.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/1058531428280840283/8b8d0b240fa9d41a93de38c4c6eec0f3.webp?size=64",
             "success": true,
-            "username": "endra"
+            "username": "endra2467"
         },
         "167857733645631489": {
-            "avatar": "https://cdn.discordapp.com/avatars/167857733645631489/52c3d08e72c9f0d3601fdc40db9e0406.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/167857733645631489/52c3d08e72c9f0d3601fdc40db9e0406.webp?size=64",
             "success": true,
-            "username": "Arby"
+            "username": "arbyyy"
         },
         "187333184340361217": {
-            "avatar": "https://cdn.discordapp.com/avatars/187333184340361217/d4d110466ef020b4463fac4ee2f74dc0.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/187333184340361217/d4d110466ef020b4463fac4ee2f74dc0.webp?size=64",
             "success": true,
             "username": "flashturtle"
         },
         "194987049848143873": {
-            "avatar": "https://cdn.discordapp.com/avatars/194987049848143873/da4a9e0ea8be6860bb91425e6c68b1c0.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/194987049848143873/da4a9e0ea8be6860bb91425e6c68b1c0.webp?size=64",
             "success": true,
             "username": "stanford1"
         },
         "202538511549595648": {
-            "avatar": "https://cdn.discordapp.com/avatars/202538511549595648/9148d629eee63e0a5b1f1abcb6c0d42d.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/202538511549595648/9148d629eee63e0a5b1f1abcb6c0d42d.webp?size=64",
             "success": true,
             "username": "its_ame"
         },
         "203377312266190848": {
-            "avatar": "https://cdn.discordapp.com/avatars/203377312266190848/4effcf4ea12122c4e40128dc25b32b3f.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/203377312266190848/4effcf4ea12122c4e40128dc25b32b3f.webp?size=64",
             "success": true,
             "username": "eziur"
         },
         "254273433494355978": {
-            "avatar": "https://cdn.discordapp.com/avatars/254273433494355978/77a1a393817827b1f34c1a273e69268e.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/254273433494355978/77a1a393817827b1f34c1a273e69268e.webp?size=64",
             "success": true,
             "username": "mayedev"
         },
         "254329157335384067": {
-            "avatar": "https://cdn.discordapp.com/avatars/254329157335384067/a878665aee6418c3a081dd89b984bcf6.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/254329157335384067/a878665aee6418c3a081dd89b984bcf6.webp?size=64",
             "success": true,
             "username": "commonmark"
         },
         "289231830702620673": {
-            "avatar": "https://cdn.discordapp.com/avatars/289231830702620673/0bd6c25f112a1c96587f5915268bc0cc.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/289231830702620673/0bd6c25f112a1c96587f5915268bc0cc.webp?size=64",
             "success": true,
             "username": "chalchis_10"
         },
         "298011058763726848": {
-            "avatar": "https://cdn.discordapp.com/avatars/298011058763726848/a87c15e90740f752ef36f9f95c58f2c3.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/298011058763726848/a87c15e90740f752ef36f9f95c58f2c3.webp?size=64",
             "success": true,
             "username": "nosbemo"
         },
         "299779317183938562": {
-            "avatar": "https://cdn.discordapp.com/avatars/299779317183938562/498440dd26e3ba6694a88bcede30610b.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/299779317183938562/498440dd26e3ba6694a88bcede30610b.webp?size=64",
             "success": true,
             "username": "ctkiwi"
         },
         "303374470188367872": {
-            "avatar": "https://cdn.discordapp.com/avatars/303374470188367872/196c18137d93e3f7a1cadd0b19c044c8.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/303374470188367872/196c18137d93e3f7a1cadd0b19c044c8.webp?size=64",
             "success": true,
             "username": "magicgum"
         },
         "321358544396091404": {
-            "avatar": "https://cdn.discordapp.com/avatars/321358544396091404/fc59ad7a426b4b66f392ae4e9a040511.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/321358544396091404/fc59ad7a426b4b66f392ae4e9a040511.webp?size=64",
             "success": true,
             "username": "almiti"
         },
         "345740829387653121": {
-            "avatar": "https://cdn.discordapp.com/avatars/345740829387653121/8e5dbd423ca944140ca9d1d5690120d0.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/345740829387653121/8e5dbd423ca944140ca9d1d5690120d0.webp?size=64",
             "success": true,
             "username": "dropdeadqueer"
         },
         "350312952991186944": {
-            "avatar": "https://cdn.discordapp.com/avatars/350312952991186944/232f6836b05fe79a6388a7fb09e2a9ec.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/350312952991186944/232f6836b05fe79a6388a7fb09e2a9ec.webp?size=64",
             "success": true,
             "username": "wowo_8"
         },
         "354412938007674890": {
-            "avatar": "https://cdn.discordapp.com/avatars/354412938007674890/74757d5ad9723a8d15a6ff38561d0c12.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/354412938007674890/74757d5ad9723a8d15a6ff38561d0c12.webp?size=64",
             "success": true,
             "username": "jade3301"
         },
         "398261219678486532": {
-            "avatar": "https://cdn.discordapp.com/embed/avatars/0.png",
+            "avatar": "https://cdn.discordapp.com/embed/avatars/0.webp?size=64",
             "success": true,
             "username": "lunarii."
         },
         "409945553993072651": {
-            "avatar": "https://cdn.discordapp.com/avatars/409945553993072651/a_9d47ee5fd402aa7b1949d0847eceffb5.gif?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/409945553993072651/a_9d47ee5fd402aa7b1949d0847eceffb5.gif?size=64",
             "success": true,
-            "username": "Mystery Mallard"
+            "username": "mysterymallard"
         },
         "432973128990326784": {
-            "avatar": "https://cdn.discordapp.com/avatars/432973128990326784/c7ac3b194ceb557fb905a0e38a7f3434.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/432973128990326784/c7ac3b194ceb557fb905a0e38a7f3434.webp?size=64",
             "success": true,
             "username": "creeperman1253"
         },
         "446297831846969364": {
-            "avatar": "https://cdn.discordapp.com/avatars/446297831846969364/96b4d5271e93d21a12363a71722ac464.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/446297831846969364/96b4d5271e93d21a12363a71722ac464.webp?size=64",
             "success": true,
             "username": "uppercase_aaaa"
         },
         "452403474605408266": {
-            "avatar": "https://cdn.discordapp.com/avatars/452403474605408266/22bd1d5d68e7284e55341f2526fc52d9.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/452403474605408266/22bd1d5d68e7284e55341f2526fc52d9.webp?size=64",
             "success": true,
             "username": "talon_rikka"
         },
         "457295470486880273": {
-            "avatar": "https://cdn.discordapp.com/avatars/457295470486880273/802a01b7c15cc7ce4b2fdbb8448f07dc.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/457295470486880273/802a01b7c15cc7ce4b2fdbb8448f07dc.webp?size=64",
             "success": true,
             "username": "iamthetrueel"
         },
         "458339234315501576": {
-            "avatar": "https://cdn.discordapp.com/avatars/458339234315501576/9bc6497caadbf0877737a716b165e15f.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/458339234315501576/e336380840e280bc16c49bf5411e763b.webp?size=64",
             "success": true,
             "username": "nobitchesinc._"
         },
         "469663273445228555": {
-            "avatar": "https://cdn.discordapp.com/avatars/469663273445228555/6b4545d6bc1065a8142bd03b61b74326.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/469663273445228555/6b4545d6bc1065a8142bd03b61b74326.webp?size=64",
             "success": true,
             "username": "corruptedflare"
         },
         "471050729893789697": {
-            "avatar": "https://cdn.discordapp.com/avatars/471050729893789697/792a0c07fb357187f5be5d690f8bc4f2.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/471050729893789697/792a0c07fb357187f5be5d690f8bc4f2.webp?size=64",
             "success": true,
             "username": "aprite"
         },
         "476853197613301781": {
-            "avatar": "https://cdn.discordapp.com/avatars/476853197613301781/c94364aeae046b0c9f9d4fa6caad8921.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/476853197613301781/c94364aeae046b0c9f9d4fa6caad8921.webp?size=64",
             "success": true,
             "username": "azanerth"
         },
         "479666364164997130": {
-            "avatar": "https://cdn.discordapp.com/avatars/479666364164997130/808d2d51fd825e48bbed400ba657b900.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/479666364164997130/808d2d51fd825e48bbed400ba657b900.webp?size=64",
             "success": true,
             "username": "cakecrab"
         },
         "486999281836883988": {
-            "avatar": "https://cdn.discordapp.com/avatars/486999281836883988/98d196ada10b64f6897fc718367a8678.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/486999281836883988/c981106e0e7c82599e86721b824fa79c.webp?size=64",
             "success": true,
             "username": "earlking"
         },
         "506551669593735181": {
-            "avatar": "https://cdn.discordapp.com/avatars/506551669593735181/8d320fbdf61c008562b93243aeb197fd.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/506551669593735181/8d320fbdf61c008562b93243aeb197fd.webp?size=64",
             "success": true,
             "username": "voiceoverpete"
         },
         "509565313692729345": {
-            "avatar": "https://cdn.discordapp.com/avatars/509565313692729345/9fdc0536609f1c28fd177918ee1b668a.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/509565313692729345/9fdc0536609f1c28fd177918ee1b668a.webp?size=64",
             "success": true,
-            "username": "Blockies"
+            "username": "blockies"
         },
         "524060680853127168": {
-            "avatar": "https://cdn.discordapp.com/avatars/524060680853127168/f191b915704249bc9c5ae0e4490be271.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/524060680853127168/f191b915704249bc9c5ae0e4490be271.webp?size=64",
             "success": true,
-            "username": "Dustopia"
+            "username": "dustopia"
         },
         "539295074216050689": {
-            "avatar": "https://cdn.discordapp.com/avatars/539295074216050689/eb25393c7cf2d78d43fff135652a1add.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/539295074216050689/eb25393c7cf2d78d43fff135652a1add.webp?size=64",
             "success": true,
             "username": "dr.rth"
         },
         "540324263211565099": {
-            "avatar": "https://cdn.discordapp.com/avatars/540324263211565099/11c52f8b6be5fb718dc6fab72a95bbbd.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/540324263211565099/11c52f8b6be5fb718dc6fab72a95bbbd.webp?size=64",
             "success": true,
             "username": "dahomieomi"
         },
         "541244602548617224": {
-            "avatar": "https://cdn.discordapp.com/avatars/541244602548617224/0d770342d399bd050954416d8920a6ab.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/541244602548617224/0d770342d399bd050954416d8920a6ab.webp?size=64",
             "success": true,
-            "username": "irl takes priority"
+            "username": "procrastination_____"
         },
         "546284669612720148": {
-            "avatar": "https://cdn.discordapp.com/avatars/546284669612720148/29698bf4e6263a6ac0c72853cd26fdb6.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/546284669612720148/29698bf4e6263a6ac0c72853cd26fdb6.webp?size=64",
             "success": true,
             "username": "tnessemo"
         },
         "553369841029873665": {
-            "avatar": "https://cdn.discordapp.com/avatars/553369841029873665/6dcf17f6c5e964194a03b3789ecd7716.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/553369841029873665/66e5d9968b7a53f90508e0f336903f51.webp?size=64",
             "success": true,
             "username": "katyusha8587"
         },
         "570704460003934218": {
-            "avatar": "https://cdn.discordapp.com/avatars/570704460003934218/52862d5f3eebb0f5700e7286a0fda9fa.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/570704460003934218/52862d5f3eebb0f5700e7286a0fda9fa.webp?size=64",
             "success": true,
             "username": "ssevenbell"
         },
         "580565909744123905": {
-            "avatar": "https://cdn.discordapp.com/avatars/580565909744123905/bce9dfe89654bd94f0484429f4674ecc.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/580565909744123905/bce9dfe89654bd94f0484429f4674ecc.webp?size=64",
             "success": true,
             "username": "toastroll"
         },
         "632104726153920512": {
-            "avatar": "https://cdn.discordapp.com/avatars/632104726153920512/f1257f7ee288e6d9d042d19e6674edd5.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/632104726153920512/f1257f7ee288e6d9d042d19e6674edd5.webp?size=64",
             "success": true,
             "username": "xbinsu"
         },
         "640645572692410382": {
-            "avatar": "https://cdn.discordapp.com/avatars/640645572692410382/b09882fd727b5ebd17682f7a4626ebae.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/640645572692410382/b09882fd727b5ebd17682f7a4626ebae.webp?size=64",
             "success": true,
             "username": "iamflamma"
         },
         "647229882937376782": {
-            "avatar": "https://cdn.discordapp.com/avatars/647229882937376782/6c88d67ba6911a241b885bc32c258cac.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/647229882937376782/6c88d67ba6911a241b885bc32c258cac.webp?size=64",
             "success": true,
             "username": "christmaschaos"
         },
         "657201429790064670": {
-            "avatar": "https://cdn.discordapp.com/avatars/657201429790064670/ad7ff6eefe243baf9664ae7d2a4c09f7.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/657201429790064670/ad7ff6eefe243baf9664ae7d2a4c09f7.webp?size=64",
             "success": true,
             "username": "rose_phoenix_"
         },
         "678020888792268825": {
-            "avatar": "https://cdn.discordapp.com/avatars/678020888792268825/5bf47a3457e5a9dc31e22f47bc6ac7e4.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/678020888792268825/5bf47a3457e5a9dc31e22f47bc6ac7e4.webp?size=64",
             "success": true,
             "username": "piigoo"
         },
         "686322675726942210": {
-            "avatar": "https://cdn.discordapp.com/avatars/686322675726942210/984cf12708e3cbeabb37a63d3c933d47.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/686322675726942210/984cf12708e3cbeabb37a63d3c933d47.webp?size=64",
             "success": true,
             "username": "dejviiii"
         },
         "694192871707902033": {
-            "avatar": "https://cdn.discordapp.com/avatars/694192871707902033/d446b9529149b9a7724397673d255dc3.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/694192871707902033/d446b9529149b9a7724397673d255dc3.webp?size=64",
             "success": true,
-            "username": "LakeAffect"
+            "username": "_lakeaffect"
         },
         "704141830081478697": {
-            "avatar": "https://cdn.discordapp.com/avatars/704141830081478697/fe70158938efaaceb5916ebcf9e2d227.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/704141830081478697/fe70158938efaaceb5916ebcf9e2d227.webp?size=64",
             "success": true,
-            "username": "Ferver"
+            "username": "ferver00"
         },
         "713825784376328214": {
-            "avatar": "https://cdn.discordapp.com/avatars/713825784376328214/3c310ecafc4494d61ea6691ae0f4bc39.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/713825784376328214/3c310ecafc4494d61ea6691ae0f4bc39.webp?size=64",
             "success": true,
             "username": "chromaticpixels"
         },
         "714299084147523585": {
-            "avatar": "https://cdn.discordapp.com/avatars/714299084147523585/4f206fe6d4455e616187b11a3e0d0c19.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/714299084147523585/4f206fe6d4455e616187b11a3e0d0c19.webp?size=64",
             "success": true,
             "username": "ella3"
         },
         "717479871001133108": {
-            "avatar": "https://cdn.discordapp.com/avatars/717479871001133108/07dccbf92408676c9bb861ccba7b4cbc.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/717479871001133108/bc9d41e816180bd2b8f68b20677c00e9.webp?size=64",
             "success": true,
             "username": "shookshrimp"
         },
         "723495887363375114": {
-            "avatar": "https://cdn.discordapp.com/avatars/723495887363375114/2862774cbb0c102a6ae1c34452c6d8df.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/723495887363375114/2862774cbb0c102a6ae1c34452c6d8df.webp?size=64",
             "success": true,
-            "username": "scratomic"
+            "username": "atom_._."
         },
         "727493063299039262": {
-            "avatar": "https://cdn.discordapp.com/avatars/727493063299039262/45adf1f3c3776b79f56a049e1f054d0e.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/727493063299039262/45adf1f3c3776b79f56a049e1f054d0e.webp?size=64",
             "success": true,
             "username": "silverblancalt"
         },
         "734630355637764128": {
-            "avatar": "https://cdn.discordapp.com/avatars/734630355637764128/4284f2c18c5e2ec044e08f5854bbbdaa.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/734630355637764128/4284f2c18c5e2ec044e08f5854bbbdaa.webp?size=64",
             "success": true,
             "username": ".eggcat"
         },
         "756070697939370009": {
-            "avatar": "https://cdn.discordapp.com/avatars/756070697939370009/31898d3cddf55df29ca4761ba0edebde.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/756070697939370009/31898d3cddf55df29ca4761ba0edebde.webp?size=64",
             "success": true,
             "username": "ccriii"
         },
         "761371710339416064": {
-            "avatar": "https://cdn.discordapp.com/avatars/761371710339416064/5a4d787e838f7cdff1e8632ada8164b8.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/761371710339416064/5a4d787e838f7cdff1e8632ada8164b8.webp?size=64",
             "success": true,
             "username": "farlostbrand"
         },
         "783240073482207242": {
-            "avatar": "https://cdn.discordapp.com/avatars/783240073482207242/4a863af653bb1ec515a3a8a01d908252.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/783240073482207242/4a863af653bb1ec515a3a8a01d908252.webp?size=64",
             "success": true,
             "username": "coopsbomb4"
         },
         "788082563176595467": {
-            "avatar": "https://cdn.discordapp.com/avatars/788082563176595467/5232a0ff41346e89b12d8aa9b832eeb9.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/788082563176595467/5232a0ff41346e89b12d8aa9b832eeb9.webp?size=64",
             "success": true,
             "username": "curliestdropplet123"
         },
         "791671062043164692": {
-            "avatar": "https://cdn.discordapp.com/avatars/791671062043164692/0939f11ad4957fac53837679ffc15578.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/791671062043164692/0939f11ad4957fac53837679ffc15578.webp?size=64",
             "success": true,
-            "username": "Commpistoned"
+            "username": "commpistoned"
         },
         "794050918324502548": {
-            "avatar": "https://cdn.discordapp.com/avatars/794050918324502548/1bc47bdeb21d002d2db3974bb1acc1a4.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/794050918324502548/1bc47bdeb21d002d2db3974bb1acc1a4.webp?size=64",
             "success": true,
             "username": "munchyaxolotls"
         },
         "794817792121503745": {
-            "avatar": "https://cdn.discordapp.com/avatars/794817792121503745/fc93bc9e2cffe4793a24249c04e12bf3.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/794817792121503745/fc93bc9e2cffe4793a24249c04e12bf3.webp?size=64",
             "success": true,
-            "username": "taytay"
+            "username": "vampiretay"
         },
         "805797840416407573": {
-            "avatar": "https://cdn.discordapp.com/avatars/805797840416407573/93f63a79c9b9e68bd3cfabef6f202e4a.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/805797840416407573/a9093711fd321dc7b4f58a1a320eaea4.webp?size=64",
             "success": true,
             "username": "the_man_of_e"
         },
         "807945971576602665": {
-            "avatar": "https://cdn.discordapp.com/avatars/807945971576602665/1360aa27cac5f5e8a0d4f82f69bee8f4.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/807945971576602665/1360aa27cac5f5e8a0d4f82f69bee8f4.webp?size=64",
             "success": true,
             "username": "siackers"
         },
         "821187703730601996": {
-            "avatar": "https://cdn.discordapp.com/avatars/821187703730601996/7df84012d9391623feec36f75d41203c.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/821187703730601996/7df84012d9391623feec36f75d41203c.webp?size=64",
             "success": true,
             "username": "cherribomb_"
         },
         "828782957635960834": {
-            "avatar": "https://cdn.discordapp.com/avatars/828782957635960834/1c10a94c48b114315c21cf1863025cc3.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/828782957635960834/1c10a94c48b114315c21cf1863025cc3.webp?size=64",
             "success": true,
             "username": "emzeragi"
         },
         "839640367921627167": {
-            "avatar": "https://cdn.discordapp.com/avatars/839640367921627167/e4b6be7452d487ad839c9464d55cc28e.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/839640367921627167/e4b6be7452d487ad839c9464d55cc28e.webp?size=64",
             "success": true,
             "username": "grimmmkinnn"
         },
         "846498984826896404": {
-            "avatar": "https://cdn.discordapp.com/avatars/846498984826896404/5a13d2fb4f285afded1edd1335384847.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/846498984826896404/5a13d2fb4f285afded1edd1335384847.webp?size=64",
             "success": true,
             "username": "astronaut.in.the.boat"
         },
         "879546132613705849": {
-            "avatar": "https://cdn.discordapp.com/avatars/879546132613705849/0136d46b15513551e4cf51491c917d2c.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/879546132613705849/0136d46b15513551e4cf51491c917d2c.webp?size=64",
             "success": true,
             "username": "zen3"
         },
         "891724893547290725": {
-            "avatar": "https://cdn.discordapp.com/avatars/891724893547290725/375a480af393774b0cf2608f06fd33e7.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/891724893547290725/375a480af393774b0cf2608f06fd33e7.webp?size=64",
             "success": true,
             "username": "hexxt_"
         },
         "931350230836838420": {
-            "avatar": "https://cdn.discordapp.com/avatars/931350230836838420/5a2bfb767368fbc3f7e04ad20018b355.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/931350230836838420/5a2bfb767368fbc3f7e04ad20018b355.webp?size=64",
             "success": true,
-            "username": "lord chronos"
+            "username": "lordchronos4654"
         },
         "963521189236580402": {
-            "avatar": "https://cdn.discordapp.com/avatars/963521189236580402/0d30268e78efd1e32d6666a81e357bcb.png?size=4096",
+            "avatar": "https://cdn.discordapp.com/avatars/963521189236580402/0d30268e78efd1e32d6666a81e357bcb.webp?size=64",
             "success": true,
             "username": "darrklion"
         }


### PR DESCRIPTION
learned how commit titles work but not descs yet so i'll just do what i remember

default avatar urls don't have a webp version stored; only convert extension to webp if url doesn't use the default avatar path. update user_info. not convert gifs to webp, because that involves more effort than it's worth. remove default_avatar_url ternary in user_data, as it seems useless -- display_avatar_url should never return none if the user exists.